### PR TITLE
Tez dependency update for tdp 1.1

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -27,7 +27,7 @@
     <parent>
       <groupId>org.apache.tez</groupId>
       <artifactId>tez</artifactId>
-      <version>0.9.1-1.0</version>
+      <version>0.9.1-2.0-SNAPSHOT</version>
     </parent>
     <artifactId>tez-docs</artifactId>
     <packaging>pom</packaging>

--- a/hadoop-shim-impls/hadoop-shim-2.7/pom.xml
+++ b/hadoop-shim-impls/hadoop-shim-2.7/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hadoop-shim-impls</artifactId>
     <groupId>org.apache.tez</groupId>
-    <version>0.9.1-1.0</version>
+    <version>0.9.1-2.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>hadoop-shim-2.7</artifactId>

--- a/hadoop-shim-impls/hadoop-shim-2.8/pom.xml
+++ b/hadoop-shim-impls/hadoop-shim-2.8/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hadoop-shim-impls</artifactId>
     <groupId>org.apache.tez</groupId>
-    <version>0.9.1-1.0</version>
+    <version>0.9.1-2.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>hadoop-shim-2.8</artifactId>

--- a/hadoop-shim-impls/pom.xml
+++ b/hadoop-shim-impls/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>tez</artifactId>
     <groupId>org.apache.tez</groupId>
-    <version>0.9.1-1.0</version>
+    <version>0.9.1-2.0-SNAPSHOT</version>
   </parent>
   <artifactId>hadoop-shim-impls</artifactId>
   <packaging>pom</packaging>

--- a/hadoop-shim/pom.xml
+++ b/hadoop-shim/pom.xml
@@ -20,7 +20,7 @@
   <parent>
      <artifactId>tez</artifactId>
      <groupId>org.apache.tez</groupId>
-     <version>0.9.1-1.0</version>
+     <version>0.9.1-2.0-SNAPSHOT</version>
   </parent>
   <artifactId>hadoop-shim</artifactId>
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
     <clover.license>${user.home}/clover.license</clover.license>
     <jetty.version>6.1.26</jetty.version>
-    <hadoop.version>3.1.4-1.0</hadoop.version>
+    <hadoop.version>3.1.4-1.0-SNAPSHOT</hadoop.version>
     <netty.version>3.6.2.Final</netty.version>
     <pig.version>0.13.0</pig.version>
     <jersey.version>1.19</jersey.version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <groupId>org.apache.tez</groupId>
   <artifactId>tez</artifactId>
   <packaging>pom</packaging>
-  <version>0.9.1-1.0</version>
+  <version>0.9.1-2.0-SNAPSHOT</version>
   <name>tez</name>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -37,8 +37,8 @@
   <properties>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
     <clover.license>${user.home}/clover.license</clover.license>
-    <hadoop.version>3.1.1-0.0</hadoop.version>
     <jetty.version>6.1.26</jetty.version>
+    <hadoop.version>3.1.4-1.0</hadoop.version>
     <netty.version>3.6.2.Final</netty.version>
     <pig.version>0.13.0</pig.version>
     <jersey.version>1.19</jersey.version>

--- a/tdp/README.md
+++ b/tdp/README.md
@@ -1,6 +1,6 @@
 # TDP Tez Notes
 
-The version 0.9.1-1.0 of Apache Hive is based on the `branch-0.9.1` tag of the Apache [repository](https://github.com/apache/tez/tree/branch-0.9.1).
+The version 0.9.1-2.0-SNAPSHOT of Apache Hive is based on the `branch-0.9.1` tag of the Apache [repository](https://github.com/apache/tez/tree/branch-0.9.1).
 
 ## Jenkinfile
 
@@ -12,7 +12,7 @@ The file `./Jenkinsfile-sample` can be used in a Jenkins / Kubernetes environmen
 mvn clean install -pl \!tez-ui -Phadoop28 -P\!hadoop27 -DskipTests
 ```
 
-The command generates a `.tar.gz` file of the release at `./tez-dist/target/tez-0.9.1-1.0.tar.gz`.
+The command generates a `.tar.gz` file of the release at `./tez-dist/target/tez-0.9.1-2.0-SNAPSHOT.tar.gz`.
 
 ## Testing parameters
 

--- a/tez-api/pom.xml
+++ b/tez-api/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.tez</groupId>
     <artifactId>tez</artifactId>
-    <version>0.9.1-1.0</version>
+    <version>0.9.1-2.0-SNAPSHOT</version>
   </parent>
   <artifactId>tez-api</artifactId>
 

--- a/tez-common/pom.xml
+++ b/tez-common/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.tez</groupId>
     <artifactId>tez</artifactId>
-    <version>0.9.1-1.0</version>
+    <version>0.9.1-2.0-SNAPSHOT</version>
   </parent>
   <artifactId>tez-common</artifactId>
 

--- a/tez-dag/pom.xml
+++ b/tez-dag/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.tez</groupId>
     <artifactId>tez</artifactId>
-    <version>0.9.1-1.0</version>
+    <version>0.9.1-2.0-SNAPSHOT</version>
   </parent>
   <properties>
     <tez.component>tez-dag</tez.component>

--- a/tez-dist/pom.xml
+++ b/tez-dist/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.tez</groupId>
     <artifactId>tez</artifactId>
-    <version>0.9.1-1.0</version>
+    <version>0.9.1-2.0-SNAPSHOT</version>
   </parent>
   <artifactId>tez-dist</artifactId>
 

--- a/tez-examples/pom.xml
+++ b/tez-examples/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.tez</groupId>
     <artifactId>tez</artifactId>
-    <version>0.9.1-1.0</version>
+    <version>0.9.1-2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>tez-examples</artifactId>

--- a/tez-ext-service-tests/pom.xml
+++ b/tez-ext-service-tests/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>tez</artifactId>
     <groupId>org.apache.tez</groupId>
-    <version>0.9.1-1.0</version>
+    <version>0.9.1-2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>tez-ext-service-tests</artifactId>

--- a/tez-mapreduce/pom.xml
+++ b/tez-mapreduce/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.tez</groupId>
     <artifactId>tez</artifactId>
-    <version>0.9.1-1.0</version>
+    <version>0.9.1-2.0-SNAPSHOT</version>
   </parent>
   <artifactId>tez-mapreduce</artifactId>
 

--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/client/NotRunningJob.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/client/NotRunningJob.java
@@ -84,11 +84,14 @@ public class NotRunningJob implements MRClientProtocol {
     ApplicationAttemptId unknownAttemptId = recordFactory
         .newRecordInstance(ApplicationAttemptId.class);
 
-    // Setting AppState to NEW and finalStatus to UNDEFINED as they are never
-    // used for a non running job
-    return ApplicationReport.newInstance(unknownAppId, unknownAttemptId, "N/A",
-        "N/A", "N/A", "N/A", 0, null, YarnApplicationState.NEW, "N/A", "N/A",
-        0, 0, FinalApplicationStatus.UNDEFINED, null, "N/A", 0.0f, "TEZ_MRR", null);
+    ApplicationReport report = recordFactory.newRecordInstance(ApplicationReport.class);
+    report.setUser("N/A");
+    report.setName("N/A");
+    report.setDiagnostics("N/A");
+    report.setTrackingUrl("N/A");
+    report.setStartTime(0);
+    report.setFinishTime(0);
+    return report;
   }
 
   NotRunningJob(ApplicationReport applicationReport, JobState jobState) {

--- a/tez-plugins/pom.xml
+++ b/tez-plugins/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.tez</groupId>
     <artifactId>tez</artifactId>
-    <version>0.9.1-1.0</version>
+    <version>0.9.1-2.0-SNAPSHOT</version>
   </parent>
   <artifactId>tez-plugins</artifactId>
   <packaging>pom</packaging>

--- a/tez-plugins/tez-aux-services/pom.xml
+++ b/tez-plugins/tez-aux-services/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>tez-plugins</artifactId>
     <groupId>org.apache.tez</groupId>
-    <version>0.9.1-1.0</version>
+    <version>0.9.1-2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>tez-aux-services</artifactId>

--- a/tez-plugins/tez-history-parser/pom.xml
+++ b/tez-plugins/tez-history-parser/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.tez</groupId>
     <artifactId>tez-plugins</artifactId>
-    <version>0.9.1-1.0</version>
+    <version>0.9.1-2.0-SNAPSHOT</version>
   </parent>
   <artifactId>tez-history-parser</artifactId>
 

--- a/tez-plugins/tez-yarn-timeline-cache-plugin/pom.xml
+++ b/tez-plugins/tez-yarn-timeline-cache-plugin/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.tez</groupId>
     <artifactId>tez-plugins</artifactId>
-    <version>0.9.1-1.0</version>
+    <version>0.9.1-2.0-SNAPSHOT</version>
   </parent>
   <artifactId>tez-yarn-timeline-cache-plugin</artifactId>
 

--- a/tez-plugins/tez-yarn-timeline-history-with-acls/pom.xml
+++ b/tez-plugins/tez-yarn-timeline-history-with-acls/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.tez</groupId>
     <artifactId>tez-plugins</artifactId>
-    <version>0.9.1-1.0</version>
+    <version>0.9.1-2.0-SNAPSHOT</version>
   </parent>
   <artifactId>tez-yarn-timeline-history-with-acls</artifactId>
 

--- a/tez-plugins/tez-yarn-timeline-history-with-fs/pom.xml
+++ b/tez-plugins/tez-yarn-timeline-history-with-fs/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.tez</groupId>
     <artifactId>tez-plugins</artifactId>
-    <version>0.9.1-1.0</version>
+    <version>0.9.1-2.0-SNAPSHOT</version>
   </parent>
   <artifactId>tez-yarn-timeline-history-with-fs</artifactId>
 

--- a/tez-plugins/tez-yarn-timeline-history/pom.xml
+++ b/tez-plugins/tez-yarn-timeline-history/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.tez</groupId>
     <artifactId>tez-plugins</artifactId>
-    <version>0.9.1-1.0</version>
+    <version>0.9.1-2.0-SNAPSHOT</version>
   </parent>
   <artifactId>tez-yarn-timeline-history</artifactId>
 

--- a/tez-runtime-internals/pom.xml
+++ b/tez-runtime-internals/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.tez</groupId>
     <artifactId>tez</artifactId>
-    <version>0.9.1-1.0</version>
+    <version>0.9.1-2.0-SNAPSHOT</version>
   </parent>
   <artifactId>tez-runtime-internals</artifactId>
 

--- a/tez-runtime-library/pom.xml
+++ b/tez-runtime-library/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.tez</groupId>
     <artifactId>tez</artifactId>
-    <version>0.9.1-1.0</version>
+    <version>0.9.1-2.0-SNAPSHOT</version>
   </parent>
   <artifactId>tez-runtime-library</artifactId>
 

--- a/tez-tests/pom.xml
+++ b/tez-tests/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.tez</groupId>
     <artifactId>tez</artifactId>
-    <version>0.9.1-1.0</version>
+    <version>0.9.1-2.0-SNAPSHOT</version>
   </parent>
   <artifactId>tez-tests</artifactId>
 

--- a/tez-tools/analyzers/job-analyzer/pom.xml
+++ b/tez-tools/analyzers/job-analyzer/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.tez</groupId>
     <artifactId>tez-perf-analyzer</artifactId>
-    <version>0.9.1-1.0</version>
+    <version>0.9.1-2.0-SNAPSHOT</version>
   </parent>
   <artifactId>tez-job-analyzer</artifactId>
 

--- a/tez-tools/analyzers/pom.xml
+++ b/tez-tools/analyzers/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.tez</groupId>
     <artifactId>tez-tools</artifactId>
-    <version>0.9.1-1.0</version>
+    <version>0.9.1-2.0-SNAPSHOT</version>
   </parent>
   <artifactId>tez-perf-analyzer</artifactId>
   <packaging>pom</packaging>

--- a/tez-tools/pom.xml
+++ b/tez-tools/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.tez</groupId>
     <artifactId>tez</artifactId>
-    <version>0.9.1-1.0</version>
+    <version>0.9.1-2.0-SNAPSHOT</version>
   </parent>
   <artifactId>tez-tools</artifactId>
   <packaging>pom</packaging>

--- a/tez-tools/tez-javadoc-tools/pom.xml
+++ b/tez-tools/tez-javadoc-tools/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.tez</groupId>
     <artifactId>tez-tools</artifactId>
-    <version>0.9.1-1.0</version>
+    <version>0.9.1-2.0-SNAPSHOT</version>
   </parent>
   <artifactId>tez-javadoc-tools</artifactId>
 

--- a/tez-tools/tez-tfile-parser/pom.xml
+++ b/tez-tools/tez-tfile-parser/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.tez</groupId>
     <artifactId>tez-tools</artifactId>
-    <version>0.9.1-1.0</version>
+    <version>0.9.1-2.0-SNAPSHOT</version>
   </parent>
   <artifactId>tez-tfile-parser</artifactId>
 

--- a/tez-ui/pom.xml
+++ b/tez-ui/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.tez</groupId>
     <artifactId>tez</artifactId>
-    <version>0.9.1-1.0</version>
+    <version>0.9.1-2.0-SNAPSHOT</version>
   </parent>
   <artifactId>tez-ui</artifactId>
   <packaging>war</packaging>


### PR DESCRIPTION
Relates to https://github.com/TOSIT-IO/TDP/pull/90

TEZ-4035 is mandatory for build with Hadoop 3.1.4